### PR TITLE
Use messages and warnings in place of print, format documentation and byte compile on install

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,6 +7,7 @@ Date: 2017-07-24
 Author: Justin Fainges
 Maintainer: Justin Fainges <Justin.Fainges@csiro.au>
 LazyData: true
+Byte-Compile: yes
 Description: Contains functions designed to facilitate the loading
     and transformation of 'Agricultural Production Systems Simulator'
     output files <https://www.apsim.info>. Input meteorological data

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,4 +23,5 @@ Imports:
     utils,
     RSQLite
 URL: https://www.apsim.info
-RoxygenNote: 6.0.1
+Encoding: UTF-8
+RoxygenNote: 6.1.0

--- a/R/LoadAPSIMouts.R
+++ b/R/LoadAPSIMouts.R
@@ -1,15 +1,15 @@
 #' Read APSIM .out files.
-#' 
+#'
 #' Reads APSIM .out files.
-#' 
-#' By default, this function will read in all output files in a directory and 
+#'
+#' By default, this function will read in all output files in a directory and
 #' combine them into a single data table. Setting \code{loadAll=FALSE} will read
 #' a single file. If the path is omitted it will try to find the file in the current
-#' working directory. Constants in outputs will be added as data columns and output 
-#' files with differing numbers of columns can also be imported although by 
-#' default this will result in an error. Care should be taken when using this 
-#' option as a different number of columns in output files usually means the 
-#' data came from a different set of reports or simulations which may not be 
+#' working directory. Constants in outputs will be added as data columns and output
+#' files with differing numbers of columns can also be imported although by
+#' default this will result in an error. Care should be taken when using this
+#' option as a different number of columns in output files usually means the
+#' data came from a different set of reports or simulations which may not be
 #' relevant to your analysis.
 #' @param dir (optional) The directory to search for .out files. This is not recursive.
 #'   If omitted, the current working directory will be used.
@@ -17,27 +17,27 @@
 #'   a single file specified by \code{dir}. Default is TRUE.
 #' @param filter A regular expression that matches the files to be loaded.
 #'   Default is \code{\\\\.out} which filters for standard apsim output files.
-#' @param returnFrame Return the data as a data frame or data table. Default is 
+#' @param returnFrame Return the data as a data frame or data table. Default is
 #'   TRUE, FALSE returns a data table.
-#' @param n Read the first n files. Good for testing/debugging. Default is 0 
+#' @param n Read the first n files. Good for testing/debugging. Default is 0
 #'   (read all files found).
-#' @param fill Where the number or names of columns is not consistent across 
-#'   files, fill missing columns with NA. Default is FALSE which will throw an 
+#' @param fill Where the number or names of columns is not consistent across
+#'   files, fill missing columns with NA. Default is FALSE which will throw an
 #'   error if the columns don't match across all files.
-#' @param addConstants Add any constants (such as ApsimVersion, Title or factor 
+#' @param addConstants Add any constants (such as ApsimVersion, Title or factor
 #'   levels) found as extra columns. Default is TRUE.
 #' @param skipEmpty Silently skip empty output files. If false, empty files
 #'   will cause an error. Default is FALSE.
 #' @export
 #' @examples
 #' \dontrun{loadApsim("c:/outputs") # load everything in the outputs directory}
-#' \dontrun{loadApsim("c:/outputs/simulation.out", loadAll=FALSE) 
+#' \dontrun{loadApsim("c:/outputs/simulation.out", loadAll=FALSE)
 #' # load a single file (note extension is required).}
-#' \dontrun{loadApsim("c:/outputs", returnFrame=FALSE, fill=TRUE) 
+#' \dontrun{loadApsim("c:/outputs", returnFrame=FALSE, fill=TRUE)
 #'   # load everything in the outputs directory, fill any missing columns and return a data table.}
-loadApsim <- compiler::cmpfun(function(dir = NULL, loadAll=TRUE, filter = "\\.out", returnFrame = TRUE, n = 0, fill=FALSE, addConstants=TRUE, skipEmpty=FALSE)
+loadApsim <- function(dir = NULL, loadAll=TRUE, filter = "\\.out", returnFrame = TRUE, n = 0, fill=FALSE, addConstants=TRUE, skipEmpty=FALSE)
 {    # this function is precompiled for a 10-12% performance increase
-    if (loadAll){ 
+    if (loadAll){
         wd <- getwd()
         if(!is.null(dir)){
             setwd(dir)
@@ -51,10 +51,10 @@ loadApsim <- compiler::cmpfun(function(dir = NULL, loadAll=TRUE, filter = "\\.ou
     }
     if (length(files == 0))
         return
-    
+
     allData <- list(NULL)
     fileCount <- 0
-    
+
     for(f in files) {
         print(f)
         if(skipEmpty && file.info(f)$size == 0)
@@ -65,7 +65,7 @@ loadApsim <- compiler::cmpfun(function(dir = NULL, loadAll=TRUE, filter = "\\.ou
         constants <- NULL
         namesFound <- FALSE
         unitsFound <- FALSE
-        
+
         while (length(oneLine <- readLines(con, n=1, warn=FALSE)) > 0) {
             if(grepl("factors = ", oneLine)){ # line contains a single line factor string
                 if(addConstants){
@@ -89,7 +89,7 @@ loadApsim <- compiler::cmpfun(function(dir = NULL, loadAll=TRUE, filter = "\\.ou
                         units <- subset(units, units != "")
                         # this shouldn't (but can) happen. e.g. (DECIMAL DEGREES) when reporting lat/lon
                         if(length(units) != length(colNames)) stop(paste("Error reading", f, "number of columns does not match number of headings."))
-                        unitsFound <- TRUE          
+                        unitsFound <- TRUE
                     } else {    # everything else is data
                         break
                     }
@@ -122,20 +122,20 @@ loadApsim <- compiler::cmpfun(function(dir = NULL, loadAll=TRUE, filter = "\\.ou
     })
     if (loadAll) setwd(wd) #restore wd
     return(allData)
-})
+}
 
 #' Extract a token from a vector of strings.
-#' 
+#'
 #' Extract a token from a character vector in a data frame containing a number
 #' of delimited tokens. Specialised version of str_split that works on vectors.
-#' 
+#'
 #' By default loadApsim will automatically create columns from constants inside
-#' the output files. However sometimes you might want to extract values from 
+#' the output files. However sometimes you might want to extract values from
 #' different data such as the file name. This is easy to do if the data is
 #' a fixed width, but it can be difficult when it's of variable length and
-#' delimited. str_split() is the most common way to deal with this sort of 
+#' delimited. str_split() is the most common way to deal with this sort of
 #' data, but it doesn't work on a vector.
-#' 
+#'
 #' getToken takes a data frame, a column of type 'character', a seperator and a token position to return
 #' each token in the given position. It then appends the token as a new column.
 #' @param x A data frame
@@ -146,14 +146,14 @@ loadApsim <- compiler::cmpfun(function(dir = NULL, loadAll=TRUE, filter = "\\.ou
 getToken <- function(x, cname, pos, sep, colName) {
     if (is.null(cname) | length(cname) != 1)
         stop("cname must be a character vector of length 1.")
-    
+
     delims <- str_count(x[, cname], sep)
-    
+
     if (min(delims) != max(delims))
         stop ("Number of delimiters is not the same in all vector elements.")
-    
+
     m<- str_split_fixed(x[, cname], "_",n= delims + 1)
-    
+
     x <- cbind(x, m[, pos])
     setnames(x, "m[, pos]", colName)
     return(x)

--- a/R/LoadAPSIMouts.R
+++ b/R/LoadAPSIMouts.R
@@ -31,12 +31,17 @@
 #'   recursive.  If omitted, the current working directory will be used.
 #' @export
 #' @examples
-#' \dontrun{loadApsim("c:/outputs") # load everything in the outputs directory}
-#' \dontrun{loadApsim("c:/outputs/simulation.out", loadAll=FALSE)
-#'   # load a single file (note extension is required).}
-#' \dontrun{loadApsim("c:/outputs", returnFrame=FALSE, fill=TRUE)
-#'   # load everything in the outputs directory, fill any missing columns and
-#'   # return a data table.}
+#' \dontrun{
+#'  loadApsim("c:/outputs")
+#'  # load everything in the outputs directory
+#'
+#'  loadApsim("c:/outputs/simulation.out", loadAll=FALSE)
+#'  # load a single file (note extension is required).
+#'
+#'  loadApsim("c:/outputs", returnFrame=FALSE, fill=TRUE)
+#'  # load everything in the outputs directory, fill any missing columns and
+#'  # return a data.table.
+#'  }
 loadApsim <- function(loadAll=TRUE,
                       filter = "\\.out",
                       returnFrame = TRUE,

--- a/R/LoadAPSIMouts.R
+++ b/R/LoadAPSIMouts.R
@@ -11,117 +11,124 @@
 #' option as a different number of columns in output files usually means the
 #' data came from a different set of reports or simulations which may not be
 #' relevant to your analysis.
-#' @param dir (optional) The directory to search for .out files. This is not recursive.
-#'   If omitted, the current working directory will be used.
 #' @param loadAll If TRUE will load all files in \code{dir}. If FALSE, will load
 #'   a single file specified by \code{dir}. Default is TRUE.
 #' @param filter A regular expression that matches the files to be loaded.
 #'   Default is \code{\\\\.out} which filters for standard apsim output files.
-#' @param returnFrame Return the data as a data frame or data table. Default is
-#'   TRUE, FALSE returns a data table.
+#' @param returnFrame Return the data as a \code{\link[base]{data.frame}} or
+#'   \code{\link[data.table]{data.table}}. Default is \code{TRUE}, \code{FALSE}
+#'   returns a \code{data.table}.
 #' @param n Read the first n files. Good for testing/debugging. Default is 0
 #'   (read all files found).
 #' @param fill Where the number or names of columns is not consistent across
-#'   files, fill missing columns with NA. Default is FALSE which will throw an
-#'   error if the columns don't match across all files.
+#'   files, fill missing columns with \code{NA}. Default is \code{FALSE} which
+#'   will throw an error if the columns don't match across all files.
 #' @param addConstants Add any constants (such as ApsimVersion, Title or factor
-#'   levels) found as extra columns. Default is TRUE.
+#'   levels) found as extra columns. Default is \code{TRUE}.
 #' @param skipEmpty Silently skip empty output files. If false, empty files
-#'   will cause an error. Default is FALSE.
+#'   will cause an error. Default is \code{FALSE}.
+#' @param dir (optional) The directory to search for .out files. This is not
+#'   recursive.  If omitted, the current working directory will be used.
 #' @export
 #' @examples
 #' \dontrun{loadApsim("c:/outputs") # load everything in the outputs directory}
 #' \dontrun{loadApsim("c:/outputs/simulation.out", loadAll=FALSE)
-#' # load a single file (note extension is required).}
+#'   # load a single file (note extension is required).}
 #' \dontrun{loadApsim("c:/outputs", returnFrame=FALSE, fill=TRUE)
-#'   # load everything in the outputs directory, fill any missing columns and return a data table.}
-loadApsim <- function(dir = NULL, loadAll=TRUE, filter = "\\.out", returnFrame = TRUE, n = 0, fill=FALSE, addConstants=TRUE, skipEmpty=FALSE)
-{    # this function is precompiled for a 10-12% performance increase
-    if (loadAll){
-        wd <- getwd()
-        if(!is.null(dir)){
-            setwd(dir)
-        }
-        else {
-            dir <- getwd()
-        }
-        files <- list.files(pattern = paste(filter, "$", sep="")) # create a list of files
-    } else {
-        files <- dir
+#'   # load everything in the outputs directory, fill any missing columns and
+#'   # return a data table.}
+loadApsim <- function(loadAll=TRUE,
+                      filter = "\\.out",
+                      returnFrame = TRUE,
+                      n = 0, fill=FALSE,
+                      addConstants=TRUE,
+                      skipEmpty=FALSE,
+                      dir = NULL) {
+  if (loadAll){
+    wd <- getwd()
+    if(!is.null(dir)){
+      setwd(dir)
     }
-    if (length(files == 0))
-        return
-
-    allData <- list(NULL)
-    fileCount <- 0
-
-    for(f in files) {
-        print(f)
-        if(skipEmpty && file.info(f)$size == 0)
-            next
-        con <- file(f, open="r")
-        count <- 0
-        size <- 1
-        constants <- NULL
-        namesFound <- FALSE
-        unitsFound <- FALSE
-
-        while (length(oneLine <- readLines(con, n=1, warn=FALSE)) > 0) {
-            if(grepl("factors = ", oneLine)){ # line contains a single line factor string
-                if(addConstants){
-                    oneLine <- stringr::str_replace(oneLine, "factors = ", "")
-                    split <- unlist(strsplit(oneLine, ";", fixed="TRUE"), use.names = FALSE)
-                    for(s in split) {
-                        constants[length(constants) + 1] <- strsplit(s, "=", fixed="TRUE")
-                    }
-                }
-            }else if(grepl("=", oneLine)){ # line contains a constant
-                    if(addConstants){
-                        constants[length(constants) + 1] <- strsplit(oneLine, " = ", fixed="TRUE")
-                    }
-                } else {
-                    if (!namesFound) { # this line is the column names
-                        colNames <- unlist(strsplit(stringr::str_trim(oneLine), " ", fixed=TRUE), use.names = FALSE)
-                        colNames <- subset(colNames, colNames != "")
-                        namesFound <- TRUE
-                    }else if (!unitsFound) { # this line is the units
-                        units <- unlist(strsplit(stringr::str_trim(oneLine), " ", fixed=TRUE), use.names = FALSE)
-                        units <- subset(units, units != "")
-                        # this shouldn't (but can) happen. e.g. (DECIMAL DEGREES) when reporting lat/lon
-                        if(length(units) != length(colNames)) stop(paste("Error reading", f, "number of columns does not match number of headings."))
-                        unitsFound <- TRUE
-                    } else {    # everything else is data
-                        break
-                    }
-            }
-            count <- count + 1
-        }
-        close(con)
-        data <- read.table(f, skip=count, header=FALSE, col.names=colNames, na.strings = c("?", "*"), stringsAsFactors=FALSE) # read the data
-        for(c in constants){
-            data[[ncol(data) + 1]] <- c[2]
-            colNames[length(colNames) + 1] <- c[1]
-        }
-        colNames <- stringr::str_trim(colNames)
-        names(data) <- colNames
-        data$fileName <- f
-        allData[[length(allData) + 1]] <- data
-        fileCount <- fileCount + 1
-        if (fileCount == n) break
+    else {
+      dir <- getwd()
     }
-    allData <- allData[!sapply(allData, is.null)]
-    if(returnFrame){
-         allData <- as.data.frame(data.table::rbindlist(allData, fill=fill))
-    } else {
-        allData <- data.table::rbindlist(allData, fill=fill)
+    files <- list.files(pattern = paste(filter, "$", sep="")) # create a list of files
+  } else {
+    files <- dir
+  }
+  if (length(files == 0))
+    return
+
+  allData <- list(NULL)
+  fileCount <- 0
+
+  for(f in files) {
+    print(f)
+    if(skipEmpty && file.info(f)$size == 0)
+      next
+    con <- file(f, open="r")
+    count <- 0
+    size <- 1
+    constants <- NULL
+    namesFound <- FALSE
+    unitsFound <- FALSE
+
+    while (length(oneLine <- readLines(con, n=1, warn=FALSE)) > 0) {
+      if(grepl("factors = ", oneLine)){ # line contains a single line factor string
+        if(addConstants){
+          oneLine <- stringr::str_replace(oneLine, "factors = ", "")
+          split <- unlist(strsplit(oneLine, ";", fixed="TRUE"), use.names = FALSE)
+          for(s in split) {
+            constants[length(constants) + 1] <- strsplit(s, "=", fixed="TRUE")
+          }
+        }
+      }else if(grepl("=", oneLine)){ # line contains a constant
+        if(addConstants){
+          constants[length(constants) + 1] <- strsplit(oneLine, " = ", fixed="TRUE")
+        }
+      } else {
+        if (!namesFound) { # this line is the column names
+          colNames <- unlist(strsplit(stringr::str_trim(oneLine), " ", fixed=TRUE), use.names = FALSE)
+          colNames <- subset(colNames, colNames != "")
+          namesFound <- TRUE
+        }else if (!unitsFound) { # this line is the units
+          units <- unlist(strsplit(stringr::str_trim(oneLine), " ", fixed=TRUE), use.names = FALSE)
+          units <- subset(units, units != "")
+          # this shouldn't (but can) happen. e.g. (DECIMAL DEGREES) when reporting lat/lon
+          if(length(units) != length(colNames)) stop(paste("Error reading", f, "number of columns does not match number of headings."))
+          unitsFound <- TRUE
+        } else {    # everything else is data
+          break
+        }
       }
-    #convert character columns to numeric where possible
-    suppressWarnings(for (i in 1:ncol(allData)){
-        if(!any(is.na(as.numeric(allData[[i]]))))
-            allData[[i]] <- as.numeric(allData[[i]])
-    })
-    if (loadAll) setwd(wd) #restore wd
-    return(allData)
+      count <- count + 1
+    }
+    close(con)
+    data <- read.table(f, skip=count, header=FALSE, col.names=colNames, na.strings = c("?", "*"), stringsAsFactors=FALSE) # read the data
+    for(c in constants){
+      data[[ncol(data) + 1]] <- c[2]
+      colNames[length(colNames) + 1] <- c[1]
+    }
+    colNames <- stringr::str_trim(colNames)
+    names(data) <- colNames
+    data$fileName <- f
+    allData[[length(allData) + 1]] <- data
+    fileCount <- fileCount + 1
+    if (fileCount == n) break
+  }
+  allData <- allData[!sapply(allData, is.null)]
+  if(returnFrame){
+    allData <- as.data.frame(data.table::rbindlist(allData, fill=fill))
+  } else {
+    allData <- data.table::rbindlist(allData, fill=fill)
+  }
+  #convert character columns to numeric where possible
+  suppressWarnings(for (i in 1:ncol(allData)){
+    if(!any(is.na(as.numeric(allData[[i]]))))
+      allData[[i]] <- as.numeric(allData[[i]])
+  })
+  if (loadAll) setwd(wd) #restore wd
+  return(allData)
 }
 
 #' Extract a token from a vector of strings.
@@ -129,32 +136,33 @@ loadApsim <- function(dir = NULL, loadAll=TRUE, filter = "\\.out", returnFrame =
 #' Extract a token from a character vector in a data frame containing a number
 #' of delimited tokens. Specialised version of str_split that works on vectors.
 #'
-#' By default loadApsim will automatically create columns from constants inside
-#' the output files. However sometimes you might want to extract values from
-#' different data such as the file name. This is easy to do if the data is
-#' a fixed width, but it can be difficult when it's of variable length and
-#' delimited. str_split() is the most common way to deal with this sort of
-#' data, but it doesn't work on a vector.
+#' By default \code{\link{loadApsim}} will automatically create columns from
+#' constants inside the output files. However sometimes you might want to
+#' extract values from different data such as the file name. This is easy to do
+#' if the data is a fixed width, but it can be difficult when it's of variable
+#' length and delimited. \code{\link[stringr]{str_split}} is the most common
+#' way to deal with this sort of data, but it doesn't work on a vector.
 #'
-#' getToken takes a data frame, a column of type 'character', a seperator and a token position to return
-#' each token in the given position. It then appends the token as a new column.
-#' @param x A data frame
+#' getToken takes a data frame, a column of type 'character', a seperator and a
+#' token position to return each token in the given position. It then appends
+#' the token as a new column.
+#' @param x A data frame.
 #' @param cname The name of the column to extract a token from.
 #' @param pos The position of the desired token in the token string.
 #' @param sep The character to use as a seperator (e.g. ":", ";", etc.) Can be multi-character.
 #' @param colName A name for the new column.
 getToken <- function(x, cname, pos, sep, colName) {
-    if (is.null(cname) | length(cname) != 1)
-        stop("cname must be a character vector of length 1.")
+  if (is.null(cname) | length(cname) != 1)
+    stop("cname must be a character vector of length 1.")
 
-    delims <- str_count(x[, cname], sep)
+  delims <- str_count(x[, cname], sep)
 
-    if (min(delims) != max(delims))
-        stop ("Number of delimiters is not the same in all vector elements.")
+  if (min(delims) != max(delims))
+    stop("Number of delimiters is not the same in all vector elements.")
 
-    m<- str_split_fixed(x[, cname], "_",n= delims + 1)
+  m<- str_split_fixed(x[, cname], "_",n= delims + 1)
 
-    x <- cbind(x, m[, pos])
-    setnames(x, "m[, pos]", colName)
-    return(x)
+  x <- cbind(x, m[, pos])
+  setnames(x, "m[, pos]", colName)
+  return(x)
 }

--- a/R/MetFunctions.R
+++ b/R/MetFunctions.R
@@ -101,9 +101,9 @@ prepareMet <- function (data, lat=stop("Latitude required."), lon=stop("Longitud
     
     # Check for standard met columns
     reqNames <- c("maxt", "mint", "radn", "rain", "year", "day")
-    print("Required column name check:")
-    print(reqNames)
-    print(reqNames %in% names(data))
+    message("Required column name check:")
+    message(reqNames)
+    message(reqNames %in% names(data))
     if (!all(reqNames %in% names(data))) stop("One or more required column names are missing.")
     
     if(ncol(data) != length(units)) stop("The number of columns in the data did not match the number of units. All data columns must have units. For unitless values use ().")
@@ -267,7 +267,7 @@ insertTavAmp <- function(met){
     data$month <- lubridate::month(as.Date(paste(data$year, data$day,sep="-"), format="%Y-%j"))
     data$meanDayT <- (data$maxt + data$mint) / 2
     mmt <- plyr::ddply(data, "month", function(df) mean(df$meanDayT))
-    if (nrow(mmt) != 12) print("WARNING: At least 12 months of data is required to generate tav and amp. Values may be inaccurate.")
+    if (nrow(mmt) != 12) warning("At least 12 months of data is required to generate tav and amp. Values may be inaccurate.")
     met@tav <- max(mmt$V1) - min(mmt$V1)
     met@amp <- mean(mmt$V1)
     return(met)

--- a/R/MetFunctions.R
+++ b/R/MetFunctions.R
@@ -1,5 +1,5 @@
 #' An S4 class used to store all information about a met file.
-#' 
+#'
 #' @export
 #' @slot const A character vector containing constants that wilkl be written to the file. Format is 'variable = value'.
 #' @slot lat A length one numeric vector.
@@ -12,25 +12,25 @@ metFile <- methods::setClass("metFile",
                     slots = c(const="character", lat="numeric", lon="numeric", tav="numeric", amp="numeric", units="character", data="data.frame"))
 
 #' Convert raw data to the correct APSIM met format.
-#' 
-#' \code{prepareMet} accepts a data frame containing met data and prepares it 
+#'
+#' \code{prepareMet} accepts a data frame containing met data and prepares it
 #' for writing to an APSIM formatted source file.
-#' 
-#' It will generate year/day columns from an existing date column (and add the required units), check to 
-#' ensure that dates are continuous and checks for the existence of required 
+#'
+#' It will generate year/day columns from an existing date column (and add the required units), check to
+#' ensure that dates are continuous and checks for the existence of required
 #' column names (year, day, radn, mint, maxt and rain).
-#' 
-#' It will interpolate 365 day leap years (e.g. no extra day from GCMs) and 
+#'
+#' It will interpolate 365 day leap years (e.g. no extra day from GCMs) and
 #' returns a metFile object that can be used with other APSIM functions.
 #' @section Importing External Data: \code{prepareMet} accepts a standard R data
-#'   frame as an argument. As such, you can use any importation package that 
-#'   returns data in or can be coerced to a data frame. Some examples: #' 
+#'   frame as an argument. As such, you can use any importation package that
+#'   returns data in or can be coerced to a data frame. Some examples: #'
 #'   \itemize{ \item Microsoft Excel files - readxl \item NetCDF - RNetCDF \item
-#'   MySQL database - RMySQL \item Generic databases (including Microsoft SQL 
+#'   MySQL database - RMySQL \item Generic databases (including Microsoft SQL
 #'   Server) - RODBC }
-#'   
+#'
 #' @section Specifiying units for data: Each data column requires a unit in order to be valid. Units need to be enclosed in parentheses.
-#'   For unitless values, use "()". Units can be specified by passing a 'units' vector to \code{prepareMet} (see example) or they may already be 
+#'   For unitless values, use "()". Units can be specified by passing a 'units' vector to \code{prepareMet} (see example) or they may already be
 #'   included in the data as would be seen in an APSIM output file. In this case, use \code{\link{loadMet}} instead.
 #' @param data A data frame containing the data to prepare.
 #' @param lat Latitude in decimal degrees.
@@ -50,20 +50,20 @@ prepareMet <- function (data, lat=stop("Latitude required."), lon=stop("Longitud
     if (!is.null(newNames) & (length(newNames) == length(data))) {
         names(data) <- newNames
     }
-    
+
     # check for existance of year and day
     colNames <- names(data)
     reqNames <- c("year", "day")
-    
+
     if (!all(reqNames %in% colNames)) {
         #at least one year/day column is missing so look for a date column
-        
+
         ifelse(date.format == "AU", date.format <- "%d/%m/%Y",
         ifelse(date.format == "DMY.", date.format <- "%d.%m.%Y",
         ifelse(date.format == "MDY.", date.format <- "%m.%d.%Y",
         ifelse(date.format == "YMD", date.format <- "%Y-%m-%d",
         ifelse(date.format == "US", date.format <- "%m/%d/%Y", date.format <- date.format)))))
-        
+
         converted <- FALSE
         for (col.idx in seq_len(ncol(data))) {
             x <- data[, col.idx]
@@ -71,20 +71,20 @@ prepareMet <- function (data, lat=stop("Latitude required."), lon=stop("Longitud
                  converted = TRUE
                  break
             }
-            
+
             if (!is.character(x) | is.factor(x)) next
             if (all(is.na(x))) next
-            
+
                 complete.x <- !(is.na(x))
                 d <- as.Date(lubridate::parse_date_time(as.character(x), date.format, quiet = TRUE))
                 d.na <- d[complete.x]
                 if (any(is.na(d.na))) next
                 data[, col.idx] <- d
                 converted <- TRUE
-            
+
             if (converted) break
         }
-        
+
         if(converted) {
             # found a date column; turn it into year and day
             data$year <- lubridate::year(data[, col.idx])
@@ -95,34 +95,34 @@ prepareMet <- function (data, lat=stop("Latitude required."), lon=stop("Longitud
         }
         else stop(paste("Could not find year/day or date columns or date column format does not match", date.format))
     }
-    
+
     # check for continuity in dates
     plyr::ddply(data, "year", checkCont)
-    
+
     # Check for standard met columns
     reqNames <- c("maxt", "mint", "radn", "rain", "year", "day")
     message("Required column name check:")
     message(reqNames)
     message(reqNames %in% names(data))
     if (!all(reqNames %in% names(data))) stop("One or more required column names are missing.")
-    
+
     if(ncol(data) != length(units)) stop("The number of columns in the data did not match the number of units. All data columns must have units. For unitless values use ().")
-    
+
     met <- metFile(data=data, lat=lat, lon=lon, units= units)
-    
+
     # add tav and amp
     met <- insertTavAmp(met)
-    
+
     return(met)
 }
 
 #' Check for met file errors.
-#' 
+#'
 #' Checks for errors as described in
 #' Wall, B.H. "TAMET: Computer program for processing meteorological data." CSIRO
 #' Australia. Division of Tropical Crops and Pastures.Tropical Agronomy Technical Memorandum
 #' (1977): No. 4, 13p.
-#' 
+#'
 #' Errors checked include:
 #' \itemize{
 #'   \item Temperature discontinuites.
@@ -130,13 +130,13 @@ prepareMet <- function (data, lat=stop("Latitude required."), lon=stop("Longitud
 #'   \item Evaporation that is too high or low.
 #'   \item Radiation that is too high or low.
 #'   }
-#'   
+#'
 #'   Note that issues found may not stop APSIM from running
 #'   but might indicate an issue with the weather data.
 #'   Warnings may not be applicable for very hot or cold climates.
-#' 
+#'
 #' Expects input in metFile object. Use prepareMet or loadMet first.
-#'   
+#'
 #' @param met Met file object.
 #' @param lmint Lower bound on minimum temperature.
 #' @param umint Upper bound on minimum temperature.
@@ -148,17 +148,17 @@ prepareMet <- function (data, lat=stop("Latitude required."), lon=stop("Longitud
 #' checkMet(met)
 checkMet <- function (met, lmint=-8, umint=32, lmaxt=10, umaxt=50){
     if (class(met) != "metFile") stop ("Error: checkMet expects a metFile object. Have you run prepareMet?")
-    
+
     if (length(met@lat) == 0 || abs(met@lat) > 90) stop ("latitude not given or out of range.")
-    
+
     met@data$maxtP1 <- c(rep(NA,1),head(met@data$maxt,-1))
     met@data$maxtP2 <- c(rep(NA,2),head(met@data$maxt,-2))
     met@data$mintP1 <- c(rep(NA,1),head(met@data$mint,-1))
     met@data$mintP2 <- c(rep(NA,2),head(met@data$mint,-2))
-    
+
     # get maximum extraterrestrial radiation
     rcal <- sirad::extrat(met@data$day, sirad::radians(met@lat))
-    
+
     # extract evaporation if it exists
     if("evap" %in% names(met@data)){
         evapCol <- met@data[,c("evap", "year", "day")]
@@ -167,35 +167,35 @@ checkMet <- function (met, lmint=-8, umint=32, lmaxt=10, umaxt=50){
         } else {
             evapCol <- NULL
         }
-    
+
     # do some more checks. Not the fastest given the loop, but this isn't run often.
     for(i in 1:nrow(met@data)) {
         # Check for maxt discontinuity.
         if(i > 3 && abs(met@data$maxtP1[i] - met@data$maxt[i] + met@data$maxtP1[i] - met@data$maxtP2[i]) > (ifelse(abs(met@lat) > 18, 19, 9)))
             warning(paste("Maximum temperature discontinuity found around", met@data$year[i], met@data$day[i]))
-        
+
         # Check for mint discontinuity.
         if(i > 3 && abs(met@data$mintP1[i] - met@data$mint[i] + met@data$mintP1[i] - met@data$mintP2[i]) > 20)
             warning(paste("Minimum temperature discontinuity found around", met@data$year[i], met@data$day[i]))
-        
+
         # Evaporation (if available) must be between -0.5 and 20 mm
         # first check for an evaporation column
         if(class(evapCol) != "NULL")
             if (evapCol[i,1] > 20 | evapCol[i,1] < -0.5)
                 warning(paste("Evaporation out of bounds on", evapCol$year[i], evapCol$day[i]))
-        
+
         # maxt must be between 10 and 50 degrees Celcius
         if(met@data$maxt[i] < 10 | met@data$maxt[i] > 50)
             warning(paste("Maximum temperature", met@data$maxt[i],"out of range for", met@data$year[i], met@data$day[i]))
-        
+
         # mint must be between -8 and 32 degrees Celcius
         if(met@data$mint[i] < -8 | met@data$mint[i] > 32)
             warning(paste("Minimum temperature", met@data$mint[i]," out of range for", met@data$year[i], met@data$day[i]))
-        
+
         # check for very low radiation values
         if(met@data$radn[i] < rcal$ExtraTerrestrialSolarRadiationDaily[i] * 0.75 * 0.1)
             warning(paste("Radiation value of", met@data$radn[i],"is low for", met@data$year[i], met@data$day[i]))
-        
+
         # check for high radiation values
         if(met@data$radn[i] > rcal$ExtraTerrestrialSolarRadiationDaily[i] * 0.75 * 1.12)
                warning(paste("Radiation value of", met@data$radn[i],"is high for", met@data$year[i], met@data$day[i]))
@@ -203,10 +203,10 @@ checkMet <- function (met, lmint=-8, umint=32, lmaxt=10, umaxt=50){
 }
 
 #' Checks a single year for continuity. Called from prepareMet.
-#' 
+#'
 #' This is an internal function used by prepareMet to check for
 #' continuity in a single year of a met file.
-#' 
+#'
 #' From tav_amp.for in the APSIM source code:
 #'      One earth orbit around the sun does not take an integral
 #'      number of days - 365 + a small part of a day.  Since the
@@ -239,20 +239,20 @@ checkCont <- function(data){
             data$day[60:365] <- data$day[60:365] + 1
             data$date[60:365] <- data$date[60:365] + 1
             data <- rbind(data[1:59,], dr, data[60:nrow(data-60),])
-        }        
-    }   
-    
+        }
+    }
+
     if(nrow(data) != data$day[nrow(data)] - data$day[1] + 1)
            warning(paste("Number of days in", data$year[1], "does not match expected number,", data$day[nrow(data)] - data$day[1] + 1))
 }
 
 #' Inserts Tav and Amp into a met object.
-#' 
-#' Amp is obtained by averaging the mean daily temperature of each month over 
-#' the entire data period resulting in twelve mean temperatures, and then 
-#' subtracting the minimum of these values from the maximum. Tav is obtained by 
+#'
+#' Amp is obtained by averaging the mean daily temperature of each month over
+#' the entire data period resulting in twelve mean temperatures, and then
+#' subtracting the minimum of these values from the maximum. Tav is obtained by
 #' averaging the twelve mean monthly temperatures.
-#' 
+#'
 #' The original documentation for the stand alone Tav_Amp program can be found at
 #' \url{http://www.apsim.info/Portals/0/OtherProducts/tav_amp.pdf}.
 #' @param met A met file object where the tav and amp will be inserted.
@@ -274,11 +274,11 @@ insertTavAmp <- function(met){
 }
 
 #' Read an APSIM formatted met file.
-#' 
+#'
 #' This function reads in a previously formatted met file. Can be useful for
 #' calculating tav and amp for a previously completed file or for reading into R
 #' for further analysis.
-#' 
+#'
 #' For reading in other formats see the Importing External Data section in \code{\link{prepareMet}}.
 #' See \code{\link{metFile}} for more information on the \code{met} object.
 #' @param f The full path to the file to read.
@@ -292,9 +292,9 @@ loadMet <- function(f)
         con <- file(f, open="r")
     } else {
         con <- url(f)
-        open(con) 
+        open(con)
     }
-    
+
     latFound <- FALSE
     lonFound <- FALSE
     tavFound <- FALSE
@@ -306,19 +306,19 @@ loadMet <- function(f)
     met <- metFile()
     count <- 0
     data <- list(NULL)
-    size <- 1    
-    
+    size <- 1
+
     while (!dataFound) {
         oneLine <- readLines(con, n=1, warn=FALSE)
         count = count + 1
         #clear out any extra white space
         oneLine <- stringr::str_trim(oneLine)
-        
+
         # skip lines starting with a comment or '[weather' or are blank
-        if(ifelse(is.na(stringr::str_locate(oneLine, "!")[1]), FALSE, stringr::str_locate(oneLine, "!")[1] == 1) || 
+        if(ifelse(is.na(stringr::str_locate(oneLine, "!")[1]), FALSE, stringr::str_locate(oneLine, "!")[1] == 1) ||
            ifelse(is.na(stringr::str_locate(oneLine, stringr::fixed("[weather"))[1]), FALSE, stringr::str_locate(oneLine, stringr::fixed("[weather"))[1] == 1) ||
            nchar(oneLine) == 0) next
-        
+
         # look for values
         if(grepl("lat", tolower(oneLine)) && !latFound) {               # look for a latitude
             met@lat <- as.numeric(stringr::str_extract(oneLine, "[-+]?[0-9]*\\.?[0-9]+"))
@@ -345,7 +345,7 @@ loadMet <- function(f)
                 met@units <- units
                 if(length(units) != length(colNames)) stop(paste("Error reading", f, "number of columns does match number of headings."))
                 unitsFound <- TRUE
-            } else {                
+            } else {
                 dataFound <- TRUE
             }
         }
@@ -358,22 +358,22 @@ loadMet <- function(f)
         if(!any(is.na(as.numeric(data[[i]]))))
             data[[i]] <- as.numeric(data[[i]])
     }
-    
+
     met@data <- data
     if(is.null(constants)){
         met@const <- ""
     } else {
         met@const <- constants
     }
-    
+
     return(met)
 }
 
 #' Write a metFile object to disk in APSIM met format.
-#' 
+#'
 #' Takes a completed metFile object (generated via \code{\link{prepareMet}} or
 #' \code{\link{loadMet}}) and writes it to disk.
-#' 
+#'
 #' Note the file will not be written if the met object is missing required
 #' information such as latitude, tav or amp. Note that while longitude is required
 #' in \code{\link{prepareMet}}, it is not strictly required by APSIM and thus is
@@ -381,13 +381,20 @@ loadMet <- function(f)
 #' mandatory when building a met file via \code{\link{prepareMet}}.
 #' @param fileName The file name to write to.
 #' @param met The metFile object to write.
+#'
+#' @examples
+#' data(Kingsthorpe)
+#' newNames <-c("Date", "maxt", "mint", "rain", "evaporation", "radn", "vp", "Wind", "RH", "SVP")
+#' units <- c("()", "(oC)", "(oC)", "(mm)", "(mm)", "(MJ/m^2/day)", "()", "()", "()", "()")
+#' KingsMet <- prepareMet(kingsData, -27.48, 151.81, newNames = newNames, units = units)
+#' writeMetFile(file.path(tempdir(), "KingsMet.met"), KingsMet)
 #' @export
 writeMetFile <- function(fileName, met){
     # do some checks
     if(length(met@lat) == 0) stop("No latitude found.")
     if(length(met@tav) == 0) stop("No tav found. Run insertTavAmp.")
     if(length(met@amp) == 0) stop("No amp found. Run insertTavAmp.")
-    
+
     con <- file(fileName, "w")
     writeLines("[weather.met.weather]", con)
     for(i in 1:length(met@const)) {

--- a/man/checkMet.Rd
+++ b/man/checkMet.Rd
@@ -31,8 +31,8 @@ Errors checked include:
   \item Evaporation that is too high or low.
   \item Radiation that is too high or low.
   }
-  
-  Note that issues found may not stop APSIM from running
+
+Note that issues found may not stop APSIM from running
   but might indicate an issue with the weather data.
   Warnings may not be applicable for very hot or cold climates.
 

--- a/man/getToken.Rd
+++ b/man/getToken.Rd
@@ -7,7 +7,7 @@
 getToken(x, cname, pos, sep, colName)
 }
 \arguments{
-\item{x}{A data frame}
+\item{x}{A data frame.}
 
 \item{cname}{The name of the column to extract a token from.}
 
@@ -22,13 +22,14 @@ Extract a token from a character vector in a data frame containing a number
 of delimited tokens. Specialised version of str_split that works on vectors.
 }
 \details{
-By default loadApsim will automatically create columns from constants inside
-the output files. However sometimes you might want to extract values from 
-different data such as the file name. This is easy to do if the data is
-a fixed width, but it can be difficult when it's of variable length and
-delimited. str_split() is the most common way to deal with this sort of 
-data, but it doesn't work on a vector.
+By default \code{\link{loadApsim}} will automatically create columns from
+constants inside the output files. However sometimes you might want to
+extract values from different data such as the file name. This is easy to do
+if the data is a fixed width, but it can be difficult when it's of variable
+length and delimited. \code{\link[stringr]{str_split}} is the most common
+way to deal with this sort of data, but it doesn't work on a vector.
 
-getToken takes a data frame, a column of type 'character', a seperator and a token position to return
-each token in the given position. It then appends the token as a new column.
+getToken takes a data frame, a column of type 'character', a seperator and a
+token position to return each token in the given position. It then appends
+the token as a new column.
 }

--- a/man/insertTavAmp.Rd
+++ b/man/insertTavAmp.Rd
@@ -13,9 +13,9 @@ insertTavAmp(met)
 A met file object to which tav and amp has been added.
 }
 \description{
-Amp is obtained by averaging the mean daily temperature of each month over 
-the entire data period resulting in twelve mean temperatures, and then 
-subtracting the minimum of these values from the maximum. Tav is obtained by 
+Amp is obtained by averaging the mean daily temperature of each month over
+the entire data period resulting in twelve mean temperatures, and then
+subtracting the minimum of these values from the maximum. Tav is obtained by
 averaging the twelve mean monthly temperatures.
 }
 \details{

--- a/man/loadApsim.Rd
+++ b/man/loadApsim.Rd
@@ -4,54 +4,56 @@
 \alias{loadApsim}
 \title{Read APSIM .out files.}
 \usage{
-loadApsim(dir = NULL, loadAll = TRUE, filter = "\\\\.out",
-  returnFrame = TRUE, n = 0, fill = FALSE, addConstants = TRUE,
-  skipEmpty = FALSE)
+loadApsim(loadAll = TRUE, filter = "\\\\.out", returnFrame = TRUE,
+  n = 0, fill = FALSE, addConstants = TRUE, skipEmpty = FALSE,
+  dir = NULL)
 }
 \arguments{
-\item{dir}{(optional) The directory to search for .out files. This is not recursive.
-If omitted, the current working directory will be used.}
-
 \item{loadAll}{If TRUE will load all files in \code{dir}. If FALSE, will load
 a single file specified by \code{dir}. Default is TRUE.}
 
 \item{filter}{A regular expression that matches the files to be loaded.
 Default is \code{\\\\.out} which filters for standard apsim output files.}
 
-\item{returnFrame}{Return the data as a data frame or data table. Default is 
-TRUE, FALSE returns a data table.}
+\item{returnFrame}{Return the data as a \code{\link[base]{data.frame}} or
+\code{\link[data.table]{data.table}}. Default is \code{TRUE}, \code{FALSE}
+returns a \code{data.table}.}
 
-\item{n}{Read the first n files. Good for testing/debugging. Default is 0 
+\item{n}{Read the first n files. Good for testing/debugging. Default is 0
 (read all files found).}
 
-\item{fill}{Where the number or names of columns is not consistent across 
-files, fill missing columns with NA. Default is FALSE which will throw an 
-error if the columns don't match across all files.}
+\item{fill}{Where the number or names of columns is not consistent across
+files, fill missing columns with \code{NA}. Default is \code{FALSE} which
+will throw an error if the columns don't match across all files.}
 
-\item{addConstants}{Add any constants (such as ApsimVersion, Title or factor 
-levels) found as extra columns. Default is TRUE.}
+\item{addConstants}{Add any constants (such as ApsimVersion, Title or factor
+levels) found as extra columns. Default is \code{TRUE}.}
 
 \item{skipEmpty}{Silently skip empty output files. If false, empty files
-will cause an error. Default is FALSE.}
+will cause an error. Default is \code{FALSE}.}
+
+\item{dir}{(optional) The directory to search for .out files. This is not
+recursive.  If omitted, the current working directory will be used.}
 }
 \description{
 Reads APSIM .out files.
 }
 \details{
-By default, this function will read in all output files in a directory and 
+By default, this function will read in all output files in a directory and
 combine them into a single data table. Setting \code{loadAll=FALSE} will read
 a single file. If the path is omitted it will try to find the file in the current
-working directory. Constants in outputs will be added as data columns and output 
-files with differing numbers of columns can also be imported although by 
-default this will result in an error. Care should be taken when using this 
-option as a different number of columns in output files usually means the 
-data came from a different set of reports or simulations which may not be 
+working directory. Constants in outputs will be added as data columns and output
+files with differing numbers of columns can also be imported although by
+default this will result in an error. Care should be taken when using this
+option as a different number of columns in output files usually means the
+data came from a different set of reports or simulations which may not be
 relevant to your analysis.
 }
 \examples{
 \dontrun{loadApsim("c:/outputs") # load everything in the outputs directory}
-\dontrun{loadApsim("c:/outputs/simulation.out", loadAll=FALSE) 
-# load a single file (note extension is required).}
-\dontrun{loadApsim("c:/outputs", returnFrame=FALSE, fill=TRUE) 
-  # load everything in the outputs directory, fill any missing columns and return a data table.}
+\dontrun{loadApsim("c:/outputs/simulation.out", loadAll=FALSE)
+  # load a single file (note extension is required).}
+\dontrun{loadApsim("c:/outputs", returnFrame=FALSE, fill=TRUE)
+  # load everything in the outputs directory, fill any missing columns and
+  # return a data table.}
 }

--- a/man/loadApsim.Rd
+++ b/man/loadApsim.Rd
@@ -50,10 +50,15 @@ data came from a different set of reports or simulations which may not be
 relevant to your analysis.
 }
 \examples{
-\dontrun{loadApsim("c:/outputs") # load everything in the outputs directory}
-\dontrun{loadApsim("c:/outputs/simulation.out", loadAll=FALSE)
-  # load a single file (note extension is required).}
-\dontrun{loadApsim("c:/outputs", returnFrame=FALSE, fill=TRUE)
-  # load everything in the outputs directory, fill any missing columns and
-  # return a data table.}
+\dontrun{
+ loadApsim("c:/outputs")
+ # load everything in the outputs directory
+
+ loadApsim("c:/outputs/simulation.out", loadAll=FALSE)
+ # load a single file (note extension is required).
+
+ loadApsim("c:/outputs", returnFrame=FALSE, fill=TRUE)
+ # load everything in the outputs directory, fill any missing columns and
+ # return a data.table.
+ }
 }

--- a/man/prepareMet.Rd
+++ b/man/prepareMet.Rd
@@ -26,29 +26,29 @@ prepareMet(data, lat = stop("Latitude required."),
 A metFile S4 class containing the prepared met data.
 }
 \description{
-\code{prepareMet} accepts a data frame containing met data and prepares it 
+\code{prepareMet} accepts a data frame containing met data and prepares it
 for writing to an APSIM formatted source file.
 }
 \details{
-It will generate year/day columns from an existing date column (and add the required units), check to 
-ensure that dates are continuous and checks for the existence of required 
+It will generate year/day columns from an existing date column (and add the required units), check to
+ensure that dates are continuous and checks for the existence of required
 column names (year, day, radn, mint, maxt and rain).
 
-It will interpolate 365 day leap years (e.g. no extra day from GCMs) and 
+It will interpolate 365 day leap years (e.g. no extra day from GCMs) and
 returns a metFile object that can be used with other APSIM functions.
 }
 \section{Importing External Data}{
  \code{prepareMet} accepts a standard R data
-  frame as an argument. As such, you can use any importation package that 
-  returns data in or can be coerced to a data frame. Some examples: #' 
+  frame as an argument. As such, you can use any importation package that
+  returns data in or can be coerced to a data frame. Some examples: #'
   \itemize{ \item Microsoft Excel files - readxl \item NetCDF - RNetCDF \item
-  MySQL database - RMySQL \item Generic databases (including Microsoft SQL 
+  MySQL database - RMySQL \item Generic databases (including Microsoft SQL
   Server) - RODBC }
 }
 
 \section{Specifiying units for data}{
  Each data column requires a unit in order to be valid. Units need to be enclosed in parentheses.
-  For unitless values, use "()". Units can be specified by passing a 'units' vector to \code{prepareMet} (see example) or they may already be 
+  For unitless values, use "()". Units can be specified by passing a 'units' vector to \code{prepareMet} (see example) or they may already be
   included in the data as would be seen in an APSIM output file. In this case, use \code{\link{loadMet}} instead.
 }
 

--- a/man/writeMetFile.Rd
+++ b/man/writeMetFile.Rd
@@ -22,3 +22,10 @@ in \code{\link{prepareMet}}, it is not strictly required by APSIM and thus is
 optional here. However, it is best practise to include it so it will remain
 mandatory when building a met file via \code{\link{prepareMet}}.
 }
+\examples{
+data(Kingsthorpe)
+newNames <-c("Date", "maxt", "mint", "rain", "evaporation", "radn", "vp", "Wind", "RH", "SVP")
+units <- c("()", "(oC)", "(oC)", "(mm)", "(mm)", "(MJ/m^2/day)", "()", "()", "()", "()")
+KingsMet <- prepareMet(kingsData, -27.48, 151.81, newNames = newNames, units = units)
+writeMetFile(file.path(tempdir(), "KingsMet.met"), KingsMet)
+}


### PR DESCRIPTION
This PR does the following things:

  - replaces `print()` with `message()` or `warning()` where appropriate such that any messages can be suppressed by using `suppressMessages()`. See this SO thread for more: https://stackoverflow.com/questions/36699272/why-is-message-a-better-choice-than-print-in-r-for-writing-a-package

  - Adds some formatting for documentation and an example in the case of `writeMetFile()` while I was there, adding links to other functions or packages where appropriate and formatting code using `\code{}` tags

  - Enables byte compiling on installation, which allows for the removal of the `compiler::cmpfun()` in LoadAPSIMouts.R

  - Adds "Encoding: UTF-8" to DESCRIPTION to build documentation properly

My main motivation was to be able to suppress messages when generating .met files using the [_nasapower_](https://adamhsparks.github.io/nasapower/) package that has a `create_met()` function that calls `writeMetFile()`. I just made some of the other changes since I thought they could be helpful.

The package passes local checks on macOS with R 3.5.1.